### PR TITLE
Add a jupyter notebook with the detectron2 fine tuning tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@
 Open source aerial imagery segmentation model fine tuning, evaluation, and prediction tools. Part of https://github.com/Sydney-Informatics-Hub/PIPE-3956-aerial-segmentation
 
 
+## Setup
+
+### Local (or interactive VM)
+
+```bash
+conda create -n aerial-segmentation python==3.9
+
+conda activate aerial-segmentation
+
+pip install -r requirements.txt
+
+pip install 'git+https://github.com/facebookresearch/detectron2.git'
+```
+
 ## Input Data Format
 
 Images and annotations in COCO JSON.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+roboflow
+torch
+torchvision
+wandb


### PR DESCRIPTION
I've converted the colab notebook to something that works on a regular jupyter notebook instance.

I got rid of that colab specific markdown in many of the cells, and just left it for the user to change input variables in code cells as required.

This also includes the fixes listed in #7 and should close out #12.