### PR TITLE
Shape regularisation and bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,14 @@ The following code snippet can be used to predict on a directory of tiles (batch
 
 
 ```bash
-python -m scripts.prediction_batch_detectron2 -i "path/to/tiles" -c "path/to/config.yml" -w "path/to/weights/model.pth" --coco "path/to/coco.json" --simplify-tolerance 0.3  threshold 0.7 --force-cpu 
+python -m scripts.prediction_batch_detectron2 -i "path/to/tiles" -c "path/to/config.yml" -w "path/to/weights/model.pth" --coco "path/to/coco.json" --simplify-tolerance 0.3  --threshold 0.7 --force-cpu 
+
+```
+
+For getting the minimum rotated rectangles in tile level, you can use the following script:
+
+```bash
+python -m scripts.prediction_batch_detectron2 -i "path/to/tiles" -c "path/to/config.yml" -w "path/to/weights/model.pth" --coco "path/to/coco.json" --minimum-rotated-rectangle --threshold 0.7 --force-cpu 
 
 ```
 

--- a/scripts/prediction_batch_detectron2.py
+++ b/scripts/prediction_batch_detectron2.py
@@ -154,12 +154,11 @@ def main(args=None):
         if args.minimum_rotated_rectangle:
             out = os.path.join(args.indir, "coco-out-mrr.json")
         else:
-            args.coco_out = os.path.join(
+            out = os.path.join(
                 args.indir, f"coco-out-tol_{str(args.simplify_tolerance)}.json"
             )
 
-    with open(out, "w") as f:
-        f.write(coco_json.toJSON())
+    f.write(coco_json.write_to_file(out))
 
 
 if __name__ == "__main__":

--- a/scripts/prediction_batch_detectron2.py
+++ b/scripts/prediction_batch_detectron2.py
@@ -152,15 +152,13 @@ def main(args=None):
     )
     if args.coco_out is None:
         if args.minimum_rotated_rectangle:
-            out = os.path.join(args.indir, "coco-out-mrr.json")
+            args.coco_out = os.path.join(args.indir, "coco-out-mrr.json")
         else:
-            out = os.path.join(
+            args.coco_out = os.path.join(
                 args.indir, f"coco-out-tol_{str(args.simplify_tolerance)}.json"
             )
-    else:
-        out = args.coco_out
 
-    coco_json.write_to_file(out)
+    coco_json.write_to_file(args.coco_out)
 
 
 if __name__ == "__main__":

--- a/scripts/prediction_batch_detectron2.py
+++ b/scripts/prediction_batch_detectron2.py
@@ -157,8 +157,10 @@ def main(args=None):
             out = os.path.join(
                 args.indir, f"coco-out-tol_{str(args.simplify_tolerance)}.json"
             )
+    else:
+        out = args.coco_out
 
-    f.write(coco_json.write_to_file(out))
+    coco_json.write_to_file(out)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In this version, the following changed:

- Added default 0.9 to shape simplification tolerance 
- Added minimum rotated rectangle (MRR) option to use instead of simplification. If this is set, simplification will be ignored.
- Fixed a bug with the saved images.

In case MRR is set, the rectangles in the corners will not look very good. However, this will make sure the shapes are as compact and simple as possible. This **partially** addresses [aerial-conversion issue #19](https://github.com/Sydney-Informatics-Hub/aerial-conversion/issues/19). [CGAL](https://stackoverflow.com/questions/76385818/cgal-python-bindings-in-2023) can be used in the future to solve this in a better way.

The following is a good-looking sample for the minimum rotated rectangles:
![Screenshot from 2023-10-11 14-00-22](https://github.com/Sydney-Informatics-Hub/aerial-segmentation/assets/10245721/bdeb4709-84ef-4f9c-a805-402542eba5b2)

And the next one is a not-very good-looking one:
![Screenshot from 2023-10-11 14-03-34](https://github.com/Sydney-Informatics-Hub/aerial-segmentation/assets/10245721/ee44262e-daa6-489f-b008-265772d16f95)

Note: predictions are not good, but this version has nothing to do with them.