### PR TITLE
Density mapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,25 @@ python -m scripts.prediction_raster_detectron2 --raster-file "path/to/raster.tif
 
 ```
 
+### Density Estimation and Mapping
+
+The repository also contains a script for density estimation. The script can be used as follows:
+
+```bash
+python -m scripts.density_map --input-path /path/to/annotation.geojson --average-storeys 1 --footprint-ratio 0.5 --tile-size 200 --area-unit utm
+
+```
+
+Where: 
+
+- `input-path` is the path to the geojson file containing the annotations, 
+- `average-storeys` is the average number of storeys in the buildings. If None is given, the script will look for the `storeys` property in the geojson file (or any column that has been specified in the `storeys-column` argument), 
+- `footprint-ratio` the ratio of area-based density to number-based density. The script calculates density in two ways: area-based and number-based. The area-based density is calculated by dividing the area of the building by the area of the tile. The number-based density is calculated by dividing the number of buildings in the tile by the area of the tile. The area-based density is then multiplied by the `footprint-ratio` and the number-based density is multiplied by `1 - footprint-ratio`. The default value is 0.5,
+- `tile-size` is the size of the tile in pixels for making a map. This basically acts as the resolution parameter, and 
+- `area-unit` is the unit of the area of the building. The area unit can be either `utm` or `meter`. `meter` will use `3857` as the EPSG code, while `utm` will use the UTM zone of the centroid of the building. The default value is `utm` for better accuracy.
+
+
+
 
 ## Contributing to the Project
 

--- a/scripts/density_map.py
+++ b/scripts/density_map.py
@@ -32,11 +32,11 @@ def storey_averager(annotation, storey_column="storeys"):
                 or row[storey_column] == "0"
                 or row[storey_column] == 0
             ):
-                annotation.drop(i, inplace=True)
+                annotation_d = annotation.drop(i)
         except KeyError:
             pass
     try:
-        average_storeys = annotation[storey_column].mean()
+        average_storeys = annotation_d[storey_column].mean()
     except KeyError:
         average_storeys = 1
         logger.warning(

--- a/scripts/density_map.py
+++ b/scripts/density_map.py
@@ -1,0 +1,184 @@
+# -*- coding: utf-8 -*-
+import logging
+
+# import geopandas as gpd
+# import rasterio as rio
+
+# set up logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def storey_averager(annotation, storey_column="storeys"):
+    """This function will get the average number of storeys of buildings in the
+    annotation geodataframe.
+
+    Args:
+        annotation (geodataframe): A geodataframe of annotations.
+
+    Returns:
+        average_storeys (int): The average number of storeys of buildings in the annotation geodataframe.
+    """
+
+    for i, row in annotation.iterrows():
+        try:
+            if (
+                row[storey_column] == "None"
+                or row[storey_column] == "0"
+                or row[storey_column] == 0
+            ):
+                annotation.drop(i, inplace=True)
+        except KeyError:
+            pass
+    try:
+        average_storeys = annotation[storey_column].mean()
+    except KeyError:
+        average_storeys = 1
+        logger.warning(
+            "No storeys column found in the annotation geodataframe. Will assume that all buildings have 1 storey."
+        )
+
+    return average_storeys
+
+
+def density_estimate_combined_area(
+    annotation,
+    crs="EPSG:3857",
+    average_storeys=None,
+    footprint_ratio: float = 0.5,
+    storey_column: str = "storeys",
+) -> float:
+    """This function will get the area of annotation geodataframe, and also get
+    the number of geometries in the annotation geodataframe, and return a
+    number that is the aera of the annotation geodataframe divided by the
+    number of geometries in the annotation geodataframe.
+
+    Args:
+        annotation (geodataframe): A geodataframe of annotations.
+        crs (str): The crs of the annotation geodataframe to calculate the area. For meters, use 'EPSG:3857'. For degrees, use 'EPSG:4326'.
+        average_storeys (int): The average number of storeys of buildings in the annotation geodataframe. If None, will not calculate the average number of storeys using the meta data. Defaults to None.
+        footprint_ratio (float): The ratio of the footprint-area-based density to number-based density calculations. It should be a number between 0 and 1. 0 means the footprint area density won't be considered and 1 means number density won't be considered. Defaults to 0.5.
+
+    Returns:
+        density (float): The area of the annotation geodataframe divided by the number of geometries in the annotation geodataframe.
+    """
+
+    assert (
+        footprint_ratio >= 0 and footprint_ratio <= 1
+    ), "footprint_ratio must be between 0 and 1"
+
+    density_area = density_estimate_area_area(
+        annotation, crs, average_storeys, storey_column
+    )
+
+    density_number = density_estimate_number_area(
+        annotation, crs, average_storeys, storey_column
+    )
+
+    density = (
+        density_area * footprint_ratio + density_number * (1 - footprint_ratio)
+    ) / 2
+
+    return density
+
+
+def density_estimate_number_area(
+    annotation, crs="EPSG:3857", average_storeys=None, storey_column: str = "storeys"
+) -> float:
+    """This function will get the area of annotation geodataframe, and also get
+    the number of geometries in the annotation geodataframe, and return a
+    number that is the aera of the annotation geodataframe divided by the
+    number of geometries in the annotation geodataframe.
+
+    Args:
+        annotation (geodataframe): A geodataframe of annotations.
+        crs (str): The crs of the annotation geodataframe to calculate the area. For meters, use 'EPSG:3857'. For degrees, use 'EPSG:4326'.
+        average_storeys (int): The average number of storeys of buildings in the annotation geodataframe. If None, will not calculate the average number of storeys using the meta data. Defaults to None.
+
+    Returns:
+        density (float): The area of the annotation geodataframe divided by the number of geometries in the annotation geodataframe.
+    """
+
+    if annotation.crs != crs:
+        annotation = annotation.to_crs(crs)
+
+    if average_storeys is None:
+        average_storeys = storey_averager(annotation, storey_column)
+        logger.info(
+            f"Average storeys is {average_storeys} for the given extent {annotation.bounds}"
+        )
+    elif average_storeys == 0:
+        average_storeys = 1
+        logger.warning(
+            "Average storeys cannot be 0. Will assume that all buildings have 1 storey."
+        )
+    else:
+        average_storeys = int(average_storeys)
+        logger.info(
+            f"Average storeys is {average_storeys} for the given extent {annotation.bounds}"
+        )
+
+    area = annotation.area
+    number = annotation.shape[0]
+
+    density = (number * average_storeys) / area
+
+    return density
+
+
+def density_estimate_area_area(
+    annotation, crs="EPSG:3857", average_storeys=None, storey_column: str = "storeys"
+) -> float:
+    """This function will get the area of annotation geodataframe, and also get
+    the number of geometries in the annotation geodataframe, and return a
+    number that is the aera of the annotation geodataframe divided by the
+    number of geometries in the annotation geodataframe.
+
+    Args:
+        annotation (geodataframe): A geodataframe of annotations.
+        crs (str): The crs of the annotation geodataframe to calculate the area. For meters, use 'EPSG:3857'. For degrees, use 'EPSG:4326'.
+        average_storeys (int): The average number of storeys of buildings in the annotation geodataframe. If None, will not calculate the average number of storeys using the meta data. Defaults to None.
+
+    Returns:
+        density (float): The area of the annotation geodataframe divided by the number of geometries in the annotation geodataframe.
+    """
+
+    if annotation.crs != crs:
+        annotation = annotation.to_crs(crs)
+
+    if average_storeys is None:
+        average_storeys = storey_averager(annotation, storey_column)
+        logger.info(
+            f"Average storeys is {average_storeys} for the given extent {annotation.bounds}"
+        )
+    elif average_storeys == 0:
+        average_storeys = 1
+        logger.warning(
+            "Average storeys cannot be 0. Will assume that all buildings have 1 storey."
+        )
+    else:
+        average_storeys = int(average_storeys)
+        logger.info(
+            f"Average storeys is {average_storeys} for the given extent {annotation.bounds}"
+        )
+
+    area = annotation.area
+
+    footprint_area = 0
+    for _, row in annotation.iterrows():
+        footprint_area += row["geometry"].area
+
+    density = (footprint_area * average_storeys) / area
+
+    return density
+
+
+def density_map_maker(geojson, average_storeys, footprint_ratio, tile_size, map_units):
+    """This function will use the density_estimate_combined_area function to
+    create a density map, by tiling the geojson."""
+
+    # make a sliding window on the geojson, with the size of tile_size
+    # for each window, calculate the density_estimate_combined_area
+    # return a density map
+
+    pass

--- a/scripts/density_map.py
+++ b/scripts/density_map.py
@@ -141,12 +141,12 @@ def density_estimate_number_area(
     # width = abs(bounds[2] - bounds[0])
     # height = abs(bounds[3] - bounds[1])
     # area = width * height
-    print("area", area)
+    # print("area", area)
     number = annotation.shape[0]
-    print("number", number)
-    print("average_storeys", average_storeys)
+    # print("number", number)
+    # print("average_storeys", average_storeys)
     density = (number * average_storeys) / area
-    print("number density", density)
+    # print("number density", density)
 
     return density
 
@@ -204,14 +204,14 @@ def density_estimate_area_area(
     # width = abs(bounds[2] - bounds[0])
     # height = abs(bounds[3] - bounds[1])
     # area = width * height
-    print("area", area)
+    # print("area", area)
     footprint_area = 0
     for _, row in annotation.iterrows():
         footprint_area += row["geometry"].area
-    print("footprint_area", footprint_area)
-    print("average_storeys", average_storeys)
+    # print("footprint_area", footprint_area)
+    # print("average_storeys", average_storeys)
     density = (footprint_area * average_storeys) / area
-    print("area density", density)
+    # print("area density", density)
 
     return density
 
@@ -320,7 +320,7 @@ def density_map_maker(
             footprint_ratio=footprint_ratio,
             area=area,
         )
-        print("grid density:", density, "\n=======")
+        # print("grid density:", density, "\n=======")
         density_map.append(density)
 
     # Create the density map

--- a/scripts/density_map.py
+++ b/scripts/density_map.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 import logging
 
-# import geopandas as gpd
+import geopandas as gpd
+
 # import rasterio as rio
+import numpy as np
+from shapely.geometry import Polygon
 
 # set up logging
 logging.basicConfig(level=logging.INFO)
@@ -43,7 +46,7 @@ def storey_averager(annotation, storey_column="storeys"):
 
 def density_estimate_combined_area(
     annotation,
-    crs="EPSG:3857",
+    crs=None,
     average_storeys=None,
     footprint_ratio: float = 0.5,
     storey_column: str = "storeys",
@@ -55,7 +58,7 @@ def density_estimate_combined_area(
 
     Args:
         annotation (geodataframe): A geodataframe of annotations.
-        crs (str): The crs of the annotation geodataframe to calculate the area. For meters, use 'EPSG:3857'. For degrees, use 'EPSG:4326'.
+        crs (str): The crs of the annotation geodataframe to calculate the area. If none is given, will rely on UTM crs. If fails, will use 'EPSG:3857' as fallback. Defaults to None.
         average_storeys (int): The average number of storeys of buildings in the annotation geodataframe. If None, will not calculate the average number of storeys using the meta data. Defaults to None.
         footprint_ratio (float): The ratio of the footprint-area-based density to number-based density calculations. It should be a number between 0 and 1. 0 means the footprint area density won't be considered and 1 means number density won't be considered. Defaults to 0.5.
 
@@ -83,7 +86,7 @@ def density_estimate_combined_area(
 
 
 def density_estimate_number_area(
-    annotation, crs="EPSG:3857", average_storeys=None, storey_column: str = "storeys"
+    annotation, crs=None, average_storeys=None, storey_column: str = "storeys"
 ) -> float:
     """This function will get the area of annotation geodataframe, and also get
     the number of geometries in the annotation geodataframe, and return a
@@ -92,12 +95,22 @@ def density_estimate_number_area(
 
     Args:
         annotation (geodataframe): A geodataframe of annotations.
-        crs (str): The crs of the annotation geodataframe to calculate the area. For meters, use 'EPSG:3857'. For degrees, use 'EPSG:4326'.
+        crs (str): The crs of the annotation geodataframe to calculate the area. If none is given, will rely on UTM crs. If fails, will use 'EPSG:3857' as fallback. Defaults to None.
         average_storeys (int): The average number of storeys of buildings in the annotation geodataframe. If None, will not calculate the average number of storeys using the meta data. Defaults to None.
 
     Returns:
         density (float): The area of the annotation geodataframe divided by the number of geometries in the annotation geodataframe.
     """
+
+    if crs is None:
+        try:
+            crs = annotation.estimalte_utm_crs()
+        except Exception as e:
+            crs = "EPSG:3857"
+            logger.warning(
+                f"Could not estimate the UTM crs of the annotation geodataframe. Will use {crs} as fallback."
+            )
+            print(e)
 
     if annotation.crs != crs:
         annotation = annotation.to_crs(crs)
@@ -127,7 +140,7 @@ def density_estimate_number_area(
 
 
 def density_estimate_area_area(
-    annotation, crs="EPSG:3857", average_storeys=None, storey_column: str = "storeys"
+    annotation, crs=None, average_storeys=None, storey_column: str = "storeys"
 ) -> float:
     """This function will get the area of annotation geodataframe, and also get
     the number of geometries in the annotation geodataframe, and return a
@@ -136,12 +149,21 @@ def density_estimate_area_area(
 
     Args:
         annotation (geodataframe): A geodataframe of annotations.
-        crs (str): The crs of the annotation geodataframe to calculate the area. For meters, use 'EPSG:3857'. For degrees, use 'EPSG:4326'.
+        crs (str): The crs of the annotation geodataframe to calculate the area. If none is given, will rely on UTM crs. If fails, will use 'EPSG:3857' as fallback. Defaults to None.
         average_storeys (int): The average number of storeys of buildings in the annotation geodataframe. If None, will not calculate the average number of storeys using the meta data. Defaults to None.
 
     Returns:
         density (float): The area of the annotation geodataframe divided by the number of geometries in the annotation geodataframe.
     """
+    if crs is None:
+        try:
+            crs = annotation.estimalte_utm_crs()
+        except Exception as e:
+            crs = "EPSG:3857"
+            logger.warning(
+                f"Could not estimate the UTM crs of the annotation geodataframe. Will use {crs} as fallback."
+            )
+            print(e)
 
     if annotation.crs != crs:
         annotation = annotation.to_crs(crs)
@@ -173,12 +195,88 @@ def density_estimate_area_area(
     return density
 
 
-def density_map_maker(geojson, average_storeys, footprint_ratio, tile_size, map_units):
+def density_map_maker(
+    gdf,
+    average_storeys: int = None,
+    footprint_ratio: float = 0.5,
+    tile_size: int = 100,
+    size_unit: str = None,
+    area_unit: str = "utm",
+):
     """This function will use the density_estimate_combined_area function to
-    create a density map, by tiling the geojson."""
+    create a density map, by tiling the geojson.
 
-    # make a sliding window on the geojson, with the size of tile_size
-    # for each window, calculate the density_estimate_combined_area
-    # return a density map
+    Args:
+        gdf (geodataframe): A geodataframe of annotations.
+        average_storeys (int): The average number of storeys of buildings in the annotation geodataframe. If None, will not calculate the average number of storeys using the meta data. Defaults to None.
+        footprint_ratio (float): The ratio of the footprint-area-based density to number-based density calculations. It should be a number between 0 and 1. 0 means the footprint area density won't be considered and 1 means number density won't be considered. Defaults to 0.5.
+        tile_size (int): The size of the tile. Defaults to 10.
+        size_unit (str): The unit of the tile size. If is None, will use the unit of the crs of the gdf or from 'area_unit'. If set to 'percent', will use the percentage of the width of the gdf bounds. Defaults to percent. Overall, this can be ignored as long as percentage of width is the preferred window size.
+        area_unit (str): The unit of the area. Defaults to "utm".
+    """
 
-    pass
+    # Prepare the gdf
+    if area_unit == "meter":
+        crs = 3857
+        gdf = gdf.to_crs(epsg=crs)
+    elif area_unit == "utm":
+        crs = gdf.estimate_utm_crs()
+        gdf = gdf.to_crs(crs)
+    elif area_unit is None:
+        crs = None
+    else:
+        logger.warning("area_unit must be 'meter', 'utm', or None.")
+
+    # Get the bounds of the gdf
+    bounds = gdf.total_bounds
+    width = abs(bounds[2] - bounds[0])
+    height = abs(bounds[3] - bounds[1])
+    x_min, y_min, x_max, y_max = bounds
+
+    # Get the tile size
+    if size_unit == "percent":
+        tile_size = width * tile_size / 100
+    elif size_unit is None:
+        pass
+    else:
+        logger.warning("size_unit must be 'percent' or None. Will assume None.")
+
+    assert tile_size > 0, "tile_size must be greater than 0."
+
+    x_coords = np.arange(x_min, x_max, tile_size)
+    y_coords = np.arange(y_min, y_max, tile_size)
+    polygons = []
+    for x in x_coords:
+        for y in y_coords:
+            polygons.append(
+                Polygon(
+                    [
+                        (x, y),
+                        (x + tile_size, y),
+                        (x + tile_size, y + tile_size),
+                        (x, y + tile_size),
+                    ]
+                )
+            )
+    grid = gpd.GeoDataFrame({"geometry": polygons}, crs=gdf.crs)
+    intersected = gpd.overlay(gdf, grid, how="intersection")
+
+    # TODO for each window, calculate the density_estimate_combined_area
+
+    for extent in intersected.geometry:
+        raster_extent = gpd.GeoDataFrame({"id": 1, "geometry": [extent]}, crs=gdf.crs)
+        tile_polygons = gdf.clip(raster_extent)
+
+        # Split multipolygon
+        tile_polygons = tile_polygons.explode(index_parts=False)
+        tile_polygons = tile_polygons.reset_index(drop=True)
+
+        intersected
+        tile_polygons
+        average_storeys
+        footprint_ratio
+        tile_size
+        size_unit
+        height
+
+    # TODO return a density map

--- a/scripts/density_map.py
+++ b/scripts/density_map.py
@@ -52,6 +52,7 @@ def density_estimate_combined_area(
     average_storeys=None,
     footprint_ratio: float = 0.5,
     storey_column: str = "storeys",
+    area: float = None,
 ) -> float:
     """This function will get the area of annotation geodataframe, and also get
     the number of geometries in the annotation geodataframe, and return a
@@ -73,11 +74,11 @@ def density_estimate_combined_area(
     ), "footprint_ratio must be between 0 and 1"
 
     density_area = density_estimate_area_area(
-        annotation, crs, average_storeys, storey_column
+        annotation, crs, average_storeys, storey_column, area
     )
 
     density_number = density_estimate_number_area(
-        annotation, crs, average_storeys, storey_column
+        annotation, crs, average_storeys, storey_column, area
     )
 
     density = (
@@ -88,7 +89,11 @@ def density_estimate_combined_area(
 
 
 def density_estimate_number_area(
-    annotation, crs=None, average_storeys=None, storey_column: str = "storeys"
+    annotation,
+    crs=None,
+    average_storeys=None,
+    storey_column: str = "storeys",
+    area=None,
 ) -> float:
     """This function will get the area of annotation geodataframe, and also get
     the number of geometries in the annotation geodataframe, and return a
@@ -132,21 +137,26 @@ def density_estimate_number_area(
         logger.info(
             f"Average storeys is {average_storeys} for the given extent {annotation.bounds}"
         )
-    bounds = annotation.total_bounds
-    width = abs(bounds[2] - bounds[0])
-    height = abs(bounds[3] - bounds[1])
-    area = width * height
-    # print("area", area)
+    # bounds = annotation.total_bounds
+    # width = abs(bounds[2] - bounds[0])
+    # height = abs(bounds[3] - bounds[1])
+    # area = width * height
+    print("area", area)
     number = annotation.shape[0]
-    # print("number", number)
-
+    print("number", number)
+    print("average_storeys", average_storeys)
     density = (number * average_storeys) / area
+    print("number density", density)
 
     return density
 
 
 def density_estimate_area_area(
-    annotation, crs=None, average_storeys=None, storey_column: str = "storeys"
+    annotation,
+    crs=None,
+    average_storeys=None,
+    storey_column: str = "storeys",
+    area: float = None,
 ) -> float:
     """This function will get the area of annotation geodataframe, and also get
     the number of geometries in the annotation geodataframe, and return a
@@ -190,16 +200,18 @@ def density_estimate_area_area(
             f"Average storeys is {average_storeys} for the given extent {annotation.bounds}"
         )
 
-    bounds = annotation.total_bounds
-    width = abs(bounds[2] - bounds[0])
-    height = abs(bounds[3] - bounds[1])
-    area = width * height
-    # print("area", area)
+    # bounds = annotation.total_bounds
+    # width = abs(bounds[2] - bounds[0])
+    # height = abs(bounds[3] - bounds[1])
+    # area = width * height
+    print("area", area)
     footprint_area = 0
     for _, row in annotation.iterrows():
         footprint_area += row["geometry"].area
-    # print("footprint_area", footprint_area)
+    print("footprint_area", footprint_area)
+    print("average_storeys", average_storeys)
     density = (footprint_area * average_storeys) / area
+    print("area density", density)
 
     return density
 
@@ -242,6 +254,7 @@ def density_map_maker(
     # Get the bounds of the gdf
     bounds = gdf.total_bounds
     width = abs(bounds[2] - bounds[0])
+    area = width * width
     x_min, y_min, x_max, y_max = bounds
 
     # Get the tile size
@@ -305,8 +318,9 @@ def density_map_maker(
             crs=crs,
             average_storeys=average_storeys,
             footprint_ratio=footprint_ratio,
+            area=area,
         )
-        # print(density)
+        print("grid density:", density, "\n=======")
         density_map.append(density)
 
     # Create the density map

--- a/scripts/density_map.py
+++ b/scripts/density_map.py
@@ -132,9 +132,13 @@ def density_estimate_number_area(
         logger.info(
             f"Average storeys is {average_storeys} for the given extent {annotation.bounds}"
         )
-
-    area = annotation.area
+    bounds = annotation.total_bounds
+    width = abs(bounds[2] - bounds[0])
+    height = abs(bounds[3] - bounds[1])
+    area = width * height
+    # print("area", area)
     number = annotation.shape[0]
+    # print("number", number)
 
     density = (number * average_storeys) / area
 
@@ -186,12 +190,15 @@ def density_estimate_area_area(
             f"Average storeys is {average_storeys} for the given extent {annotation.bounds}"
         )
 
-    area = annotation.area
-
+    bounds = annotation.total_bounds
+    width = abs(bounds[2] - bounds[0])
+    height = abs(bounds[3] - bounds[1])
+    area = width * height
+    # print("area", area)
     footprint_area = 0
     for _, row in annotation.iterrows():
         footprint_area += row["geometry"].area
-
+    # print("footprint_area", footprint_area)
     density = (footprint_area * average_storeys) / area
 
     return density
@@ -299,7 +306,7 @@ def density_map_maker(
             average_storeys=average_storeys,
             footprint_ratio=footprint_ratio,
         )
-        print(density)
+        # print(density)
         density_map.append(density)
 
     # Create the density map
@@ -347,7 +354,7 @@ def density_maker_geojson(
         area_unit=area_unit,
     )
 
-    print("Grid:\n", grid.density)
+    print("Grid:\n", grid)
 
     # save the density map
     if output_path is not None:

--- a/scripts/density_map.py
+++ b/scripts/density_map.py
@@ -54,10 +54,10 @@ def density_estimate_combined_area(
     storey_column: str = "storeys",
     area: float = None,
 ) -> float:
-    """This function will get the area of annotation geodataframe, and also get
-    the number of geometries in the annotation geodataframe, and return a
-    number that is the area of the annotation geodataframe divided by the
-    number of geometries in the annotation geodataframe.
+    """This function uses the density_estimate_area_area and
+    density_estimate_number_area functions to create a combined density
+    estimate. It uses the footprint_ratio to determine the ratio of the two
+    density estimates.
 
     Args:
         annotation (geodataframe): A geodataframe of annotations.
@@ -66,7 +66,7 @@ def density_estimate_combined_area(
         footprint_ratio (float): The ratio of the footprint-area-based density to number-based density calculations. It should be a number between 0 and 1. 0 means the footprint area density won't be considered and 1 means number density won't be considered. Defaults to 0.5.
 
     Returns:
-        density (float): The area of the annotation geodataframe divided by the number of geometries in the annotation geodataframe.
+        density (float): The combined density estimate.
     """
 
     assert (
@@ -97,8 +97,8 @@ def density_estimate_number_area(
 ) -> float:
     """This function will get the area of annotation geodataframe, and also get
     the number of geometries in the annotation geodataframe, and return a
-    number that is the area of the annotation geodataframe divided by the
-    number of geometries in the annotation geodataframe.
+    number that is the number of geometries in the annotation geodataframe
+    divided by area of the annotation geodataframe.
 
     Args:
         annotation (geodataframe): A geodataframe of annotations.
@@ -106,7 +106,7 @@ def density_estimate_number_area(
         average_storeys (int): The average number of storeys of buildings in the annotation geodataframe. If None, will not calculate the average number of storeys using the meta data. Defaults to None.
 
     Returns:
-        density (float): The area of the annotation geodataframe divided by the number of geometries in the annotation geodataframe.
+        density (float): The number of geometries in the annotation geodataframe divided by the area of the annotation geodataframe.
     """
 
     if crs is None:
@@ -160,8 +160,8 @@ def density_estimate_area_area(
 ) -> float:
     """This function will get the area of annotation geodataframe, and also get
     the number of geometries in the annotation geodataframe, and return a
-    number that is the area of the annotation geodataframe divided by the
-    number of geometries in the annotation geodataframe.
+    number that is the total area of geometries in the annotation geodataframe
+    divided by the area of the annotation geodataframe.
 
     Args:
         annotation (geodataframe): A geodataframe of annotations.
@@ -169,7 +169,7 @@ def density_estimate_area_area(
         average_storeys (int): The average number of storeys of buildings in the annotation geodataframe. If None, will not calculate the average number of storeys using the meta data. Defaults to None.
 
     Returns:
-        density (float): The area of the annotation geodataframe divided by the number of geometries in the annotation geodataframe.
+        density (float): The area of geometries in the annotation geodataframe divided by the area of annotation.
     """
     if crs is None:
         try:

--- a/scripts/density_map.py
+++ b/scripts/density_map.py
@@ -223,6 +223,7 @@ def density_map_maker(
     tile_size: int = 100,
     size_unit: str = None,
     area_unit: str = "utm",
+    storey_column: str = "storeys",
 ) -> gpd.GeoDataFrame:
     """This function will use the density_estimate_combined_area function to
     create a density map, by tiling the geojson.
@@ -317,6 +318,7 @@ def density_map_maker(
             tile_polygons,
             crs=crs,
             average_storeys=average_storeys,
+            storey_column=storey_column,
             footprint_ratio=footprint_ratio,
             area=area,
         )
@@ -337,6 +339,7 @@ def density_maker_geojson(
     size_unit: str = None,
     area_unit: str = "utm",
     output_path: str = None,
+    storey_column: str = "storeys",
 ) -> gpd.GeoDataFrame:
     """This function is a wrapper function for density_map_maker calculating
     and saving the density map as a geojson.
@@ -366,6 +369,7 @@ def density_maker_geojson(
         tile_size=tile_size,
         size_unit=size_unit,
         area_unit=area_unit,
+        storey_column=storey_column,
     )
 
     print("Grid:\n", grid)
@@ -406,6 +410,13 @@ def create_parser():
         type=int,
         default=None,
         help="The average number of storeys of buildings in the annotation geodataframe. If None, will not calculate the average number of storeys using the meta data. Defaults to None.",
+    )
+    parser.add_argument(
+        "--storey-column",
+        "-s",
+        type=str,
+        default="storeys",
+        help="The column name of the storey information. Defaults to 'storeys'.",
     )
     parser.add_argument(
         "--footprint-ratio",
@@ -450,6 +461,7 @@ def main(args=None):
         size_unit=args.size_unit,
         area_unit=args.area_unit,
         output_path=args.output_path,
+        storey_column=args.storey_column,
     )
 
 

--- a/scripts/fine_tuning_detectron2.py
+++ b/scripts/fine_tuning_detectron2.py
@@ -27,9 +27,9 @@ class Trainer(DefaultTrainer):
         ret = super().build_hooks()
         ret.append(
             BestCheckpointer(
-                eval_period=-1,
+                eval_period=1,
                 checkpointer=DetectionCheckpointer(self.model, cfg.OUTPUT_DIR),
-                val_metric="bbox/AP50",
+                val_metric="mask_rcnn/accuracy",
             )
         )
         return ret


### PR DESCRIPTION
This is a ~WIP (draft)~ script for making density maps. 

Density maps will be created using a given extent, a geojson, or a raster and an accompanying geojson.

It calculates using the following methods:

1. (n_buildings*avg_storeys/extent_area)
2. (building_area_sums*avg_storeys/extent_area)
3. combining 1 and 2

The calculations above are done on a grid level and a map is then generated.

A sample command to run:

```
python -m scripts.density_map --input-path /home/sahand/Data/GIS2COCO/test_extent_1/1_full_predictions_002-orthogonal.geojson --average-storeys 1 --footprint-ratio 0.5 --tile-size 200 --area-unit utm
```

Result:
![Screenshot from 2023-12-01 16-45-45](https://github.com/Sydney-Informatics-Hub/aerial-segmentation/assets/10245721/701e0052-15a6-45e5-9c0e-d54e730b9f0e)

